### PR TITLE
build(deps): bump GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/actions/composer/action.yml
+++ b/.github/actions/composer/action.yml
@@ -58,7 +58,7 @@ runs:
         COMPOSER_CONFIG: ${{ inputs.COMPOSER_CONFIG }}
 
     - name: Install Composer dependencies
-      uses: ramsey/composer-install@v3
+      uses: ramsey/composer-install@v4
       if: ${{ inputs.INSTALL_AND_CACHE == 'true' }}
       with:
         composer-options: ${{ inputs.COMPOSER_ARGS }}

--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -44,7 +44,7 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
 
-      - uses: webfactory/ssh-agent@v0.9.1
+      - uses: webfactory/ssh-agent@v0.10.0
         if: ${{ inputs.needs-auth }}
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -56,7 +56,7 @@ jobs:
       - name: Build assets
         run: ${{ inputs.build-cmd }}
 
-      - uses: stefanzweifel/git-auto-commit-action@v5
+      - uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: "chore: 🤖 Build assets"
           # file_pattern: ${{ inputs.file-pattern }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
 
     - name: Get changed files
       id: changed-files
-      uses: tj-actions/changed-files@v45
+      uses: tj-actions/changed-files@v47
 
     # - name: Run PHPCS
     #   if: steps.changed-files.outputs.all_changed_files != '' && steps.check_composer.outputs.files_exists == 'true'

--- a/.github/workflows/composer-update.yml
+++ b/.github/workflows/composer-update.yml
@@ -72,7 +72,7 @@ jobs:
       - run: echo "NOW=$(TZ=Europe/Paris date +'%Y-%m-%d %H:%M')" >> $GITHUB_ENV
 
       - name: Generate PR/commit summary
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         if: ${{ steps.composer_diff.outputs.composer_diff_exit_code != 0 }}
         id: summary
         env:
@@ -167,7 +167,7 @@ jobs:
 
           echo "${{ steps.summary.outputs.result }}" | cat - CHANGELOG.md > temp && mv temp CHANGELOG.md
 
-      - uses: peter-evans/create-pull-request@v7
+      - uses: peter-evans/create-pull-request@v8
         if: ${{ steps.composer_diff.outputs.composer_diff_exit_code != 0 }}
         env:
           NOW: ${{ env.NOW }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -39,7 +39,7 @@ jobs:
       steps:
         - uses: actions/checkout@v6
 
-        - uses: webfactory/ssh-agent@v0.9.1
+        - uses: webfactory/ssh-agent@v0.10.0
           with:
             ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
 

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             **/*.js

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Get branch names
         id: branch-names
-        uses: tj-actions/branch-names@v8
+        uses: tj-actions/branch-names@v9
 
       - name: Checkout
         if: ${{ steps.branch-names.outputs.current_branch == 'update-dependencies' }}
@@ -27,7 +27,7 @@ jobs:
           cb="$(git show -s --format=%b)"
           echo "commit_body<<EOF"$'\n'"$cb"$'\n'EOF >> $GITHUB_OUTPUT
 
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         if: ${{ steps.branch-names.outputs.current_branch == 'update-dependencies' }}
         id: release-tag
         env:

--- a/.github/workflows/stylelint.yml
+++ b/.github/workflows/stylelint.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - name: Get changed files
         id: changed-files
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             **/*.scss

--- a/.github/workflows/trigger-update-dependencies.yml
+++ b/.github/workflows/trigger-update-dependencies.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       targets: ${{ steps.targets.outputs.result }}
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         id: targets
         env:
           TOKEN: ${{ secrets.TOKEN }}


### PR DESCRIPTION
## Summary

Upgrade all GitHub Actions still running on the deprecated Node.js 20 runtime, ahead of the **June 2, 2026** enforcement deadline.

| Action | Change | Files |
|--------|--------|-------|
| `actions/github-script` | `v7` → `v8` | composer-update, trigger-update-dependencies, release |
| `peter-evans/create-pull-request` | `v7` → `v8` | composer-update |
| `webfactory/ssh-agent` | `v0.9.1` → `v0.10.0` | build-assets, deploy-production |
| `stefanzweifel/git-auto-commit-action` | `v5` → `v7` | build-assets |
| `tj-actions/changed-files` | `v45` → `v47` | ci, eslint, stylelint |
| `tj-actions/branch-names` | `v8` → `v9` | release |
| `ramsey/composer-install` | `v3` → `v4` | composer action |

All upgrades have been verified for breaking changes — none affect our current usage.

### Not yet upgradable (no Node 24 version available)

- `andstor/file-existence-action@v3` — high risk, monitor for updates
- `adrianjost/files-sync-action@v2.1.0` — high risk, monitor for updates
- `softprops/action-gh-release@v2` — medium risk, actively maintained
- `googleapis/release-please-action@v4` — medium risk, Google-maintained

## Test plan

- [ ] Verify `composer-update` workflow runs successfully
- [ ] Verify `release` workflow tags correctly on merge
- [ ] Verify `build-assets` workflow builds and auto-commits
- [ ] Verify `ci` / `eslint` / `stylelint` lint workflows detect changed files correctly
- [ ] Verify `deploy-production` SSH agent works on self-hosted runner