### PR TITLE
feat: add reusable bundle analysis and history workflows

### DIFF
--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -1,0 +1,321 @@
+name: Bundle Analysis
+
+on:
+    workflow_call:
+        inputs:
+            build_command:
+                description: 'Build command to run (e.g. npm run build:client)'
+                required: true
+                type: string
+            bundle_patterns:
+                description: 'JSON array of {name, glob} objects for bundle measurement'
+                required: true
+                type: string
+            build_env:
+                description: 'JSON object of environment variables for the build step'
+                required: false
+                type: string
+                default: '{}'
+            node_version:
+                description: 'Node.js version to use'
+                required: false
+                type: string
+                default: '20'
+            npm_install_args:
+                description: 'Extra arguments for npm ci (e.g. --legacy-peer-deps)'
+                required: false
+                type: string
+                default: ''
+            use_size_limit:
+                description: 'Run size-limit budget check'
+                required: false
+                type: boolean
+                default: false
+            treemap_path:
+                description: 'Path to the stats.html treemap file after build (empty to skip)'
+                required: false
+                type: string
+                default: ''
+        secrets:
+            GH_TOKEN:
+                description: 'GitHub token for private npm packages'
+                required: true
+
+permissions:
+    contents: read
+    pull-requests: write
+    actions: read
+
+jobs:
+    bundle-analysis:
+        runs-on: self-hosted
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ inputs.node_version }}
+                  cache: 'npm'
+
+            - name: Create .npmrc
+              run: |
+                  echo "@humanoidfr:registry=http://npm.pkg.github.com/" > .npmrc
+                  echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_TOKEN }}" >> .npmrc
+
+            # --- PR branch build ---
+            - name: Install dependencies
+              run: npm ci ${{ inputs.npm_install_args }}
+
+            - name: Build PR branch
+              run: ${{ inputs.build_command }}
+              env: ${{ fromJSON(inputs.build_env) }}
+
+            - name: Save treemap for later upload
+              if: inputs.treemap_path != ''
+              run: cp "${{ inputs.treemap_path }}" /tmp/bundle-treemap-stats.html
+
+            - name: Run size-limit
+              if: inputs.use_size_limit
+              id: size-limit
+              run: |
+                  echo "## Size Limit Report" >> "$GITHUB_STEP_SUMMARY"
+                  echo "" >> "$GITHUB_STEP_SUMMARY"
+
+                  OUTPUT=$(./node_modules/.bin/size-limit --json 2>&1) || true
+                  echo "$OUTPUT"
+
+                  ./node_modules/.bin/size-limit 2>&1 | tee -a "$GITHUB_STEP_SUMMARY" || {
+                    echo "size_failed=true" >> "$GITHUB_OUTPUT"
+                  }
+
+                  echo "$OUTPUT" > /tmp/size-limit-pr.json
+
+            - name: Measure PR file sizes (raw + gzip)
+              run: |
+                  node -e "
+                    const fs = require('fs');
+                    const zlib = require('zlib');
+                    const { execSync } = require('child_process');
+                    const patterns = ${{ inputs.bundle_patterns }};
+                    const results = patterns.map(p => {
+                      const files = execSync('ls ' + p.glob + ' 2>/dev/null || true', {encoding:'utf8'}).trim().split('\n').filter(Boolean);
+                      let size = 0, gzip = 0;
+                      for (const f of files) {
+                        try {
+                          const buf = fs.readFileSync(f);
+                          size += buf.length;
+                          gzip += zlib.gzipSync(buf, { level: 9 }).length;
+                        } catch {}
+                      }
+                      return { name: p.name, size, gzip };
+                    });
+                    fs.writeFileSync('/tmp/raw-sizes-pr.json', JSON.stringify(results));
+                    console.log(JSON.stringify(results, null, 2));
+                  "
+
+            # --- Base branch build (for comparison) ---
+            - name: Checkout base branch
+              uses: actions/checkout@v4
+              with:
+                  ref: ${{ github.event.pull_request.base.sha }}
+                  clean: false
+
+            - name: Create .npmrc (base)
+              run: |
+                  echo "@humanoidfr:registry=http://npm.pkg.github.com/" > .npmrc
+                  echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_TOKEN }}" >> .npmrc
+
+            - name: Install dependencies (base)
+              run: npm ci ${{ inputs.npm_install_args }}
+
+            - name: Build base branch
+              run: ${{ inputs.build_command }}
+
+            - name: Measure base file sizes (raw + gzip)
+              run: |
+                  node -e "
+                    const fs = require('fs');
+                    const zlib = require('zlib');
+                    const { execSync } = require('child_process');
+                    const patterns = ${{ inputs.bundle_patterns }};
+                    const results = patterns.map(p => {
+                      const files = execSync('ls ' + p.glob + ' 2>/dev/null || true', {encoding:'utf8'}).trim().split('\n').filter(Boolean);
+                      let size = 0, gzip = 0;
+                      for (const f of files) {
+                        try {
+                          const buf = fs.readFileSync(f);
+                          size += buf.length;
+                          gzip += zlib.gzipSync(buf, { level: 9 }).length;
+                        } catch {}
+                      }
+                      return { name: p.name, size, gzip };
+                    });
+                    fs.writeFileSync('/tmp/raw-sizes-base.json', JSON.stringify(results));
+                    console.log(JSON.stringify(results, null, 2));
+                  "
+
+            # --- Restore treemap and upload ---
+            - name: Restore treemap
+              if: inputs.treemap_path != ''
+              run: |
+                  mkdir -p "$(dirname '${{ inputs.treemap_path }}')"
+                  cp /tmp/bundle-treemap-stats.html "${{ inputs.treemap_path }}"
+
+            - name: Upload bundle visualization
+              if: inputs.treemap_path != ''
+              uses: actions/upload-artifact@v4
+              with:
+                  name: bundle-treemap
+                  path: ${{ inputs.treemap_path }}
+                  retention-days: 14
+
+            - name: Comment PR with size report
+              if: always()
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const fs = require('fs');
+
+                      // --- Artifact download URL ---
+                      let artifactUrl = null;
+                      const treemapPath = '${{ inputs.treemap_path }}';
+                      if (treemapPath) {
+                        try {
+                          const { data: { artifacts } } = await github.rest.actions.listWorkflowRunArtifacts({
+                            owner: context.repo.owner,
+                            repo: context.repo.repo,
+                            run_id: context.runId,
+                          });
+                          const treemap = artifacts.find(a => a.name === 'bundle-treemap');
+                          if (treemap) {
+                            const { data: run } = await github.rest.actions.getWorkflowRun({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              run_id: context.runId,
+                            });
+                            artifactUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/suites/${run.check_suite_id}/artifacts/${treemap.id}`;
+                          }
+                        } catch {}
+                      }
+
+                      // --- Parse outputs ---
+                      let sizeLimitResults = [];
+                      let rawPr = [];
+                      let rawBase = [];
+                      try { sizeLimitResults = JSON.parse(fs.readFileSync('/tmp/size-limit-pr.json', 'utf8')); } catch {}
+                      try { rawPr = JSON.parse(fs.readFileSync('/tmp/raw-sizes-pr.json', 'utf8')); } catch {}
+                      try { rawBase = JSON.parse(fs.readFileSync('/tmp/raw-sizes-base.json', 'utf8')); } catch {}
+
+                      // Lookup maps by name
+                      const baseByName = {};
+                      for (const r of rawBase) baseByName[r.name] = r;
+                      const budgetByName = {};
+                      for (const r of sizeLimitResults) budgetByName[r.name] = r;
+
+                      // --- Size comparison table ---
+                      let allPassed = true;
+                      let sizeTable = '';
+                      if (rawPr.length > 0) {
+                        const fmtKB = (bytes) => `${(bytes / 1024).toFixed(1)} KB`;
+
+                        const rows = rawPr.map(pr => {
+                          const base = baseByName[pr.name];
+                          const budget = budgetByName[pr.name];
+                          const diffBytes = base ? pr.size - base.size : null;
+                          const passed = !budget || !budget.sizeLimit || budget.size <= budget.sizeLimit;
+                          if (!passed) allPassed = false;
+
+                          const baseStr = base ? fmtKB(base.size) : '-';
+                          const prStr = fmtKB(pr.size);
+                          const gzipStr = pr.gzip ? fmtKB(pr.gzip) : '-';
+
+                          let budgetStr = '-';
+                          if (budget && budget.sizeLimit) {
+                            budgetStr = `${passed ? '\u2705' : '\u{1f534}'} ${fmtKB(budget.sizeLimit)}`;
+                          }
+
+                          let diffStr = '-';
+                          if (diffBytes !== null) {
+                            const absDiff = Math.abs(diffBytes);
+                            if (absDiff < 100) {
+                              diffStr = '\u2705 \u00b10';
+                            } else if (diffBytes > 0) {
+                              diffStr = `\u{1f53a} +${fmtKB(absDiff)}`;
+                            } else {
+                              diffStr = `\u{1f53d} -${fmtKB(absDiff)}`;
+                            }
+                          }
+
+                          return `| ${pr.name} | ${baseStr} | ${prStr} | ${gzipStr} | ${diffStr} | ${budgetStr} |`;
+                        });
+
+                        sizeTable = [
+                          '| Bundle | Base (main) | PR | Gzip | Diff | Budget (gzip) |',
+                          '|--------|------------:|---:|-----:|------|---------------|',
+                          ...rows,
+                        ].join('\n');
+                      } else {
+                        sizeTable = '_\u26a0\ufe0f Size limit report unavailable_';
+                      }
+
+                      // --- Build comment body ---
+                      const statusIcon = allPassed ? '\u2705' : '\u{1f534}';
+                      const bodyParts = [
+                        `### \u{1f4e6} Bundle Analysis ${statusIcon}`,
+                        '',
+                        '#### \u{1f4cf} Size Limit',
+                        '',
+                        sizeTable,
+                      ];
+
+                      if (treemapPath && artifactUrl) {
+                        bodyParts.push(
+                          '',
+                          '#### \u{1f5fa}\ufe0f Bundle Treemap',
+                          '',
+                          '| Artifact | Lien |',
+                          '|----------|------|',
+                          `| \u{1f4ca} \`bundle-treemap\` (stats.html) | ${artifactUrl ? `[\u2b07\ufe0f T\u00e9l\u00e9charger](${artifactUrl})` : '\u23f3 En cours...'} |`,
+                          '',
+                          '> \u{1f4a1} Ouvrir `stats.html` dans un navigateur pour visualiser la composition du bundle.',
+                        );
+                      }
+
+                      bodyParts.push(
+                        '',
+                        `> \u{1f4c8} [Historique des tailles](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/gh-pages/bundle-history/data.json) (mis \u00e0 jour apr\u00e8s chaque merge sur main)`,
+                      );
+
+                      const body = bodyParts.join('\n');
+
+                      // --- Post or update comment ---
+                      const { data: comments } = await github.rest.issues.listComments({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: context.issue.number,
+                      });
+                      const existing = comments.find(c => c.body.includes('### '));
+                      const marker = '\u{1f4e6} Bundle Analysis';
+
+                      const existingComment = comments.find(c => c.body.includes(marker));
+
+                      if (existingComment) {
+                        await github.rest.issues.updateComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          comment_id: existingComment.id,
+                          body,
+                        });
+                      } else {
+                        await github.rest.issues.createComment({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.issue.number,
+                          body,
+                        });
+                      }
+
+            - name: Fail if size budget exceeded
+              if: inputs.use_size_limit && steps.size-limit.outputs.size_failed == 'true'
+              run: exit 1

--- a/.github/workflows/bundle-history.yml
+++ b/.github/workflows/bundle-history.yml
@@ -1,0 +1,211 @@
+name: Bundle History
+
+on:
+    workflow_call:
+        inputs:
+            build_command:
+                description: 'Build command to run (e.g. npm run build:client)'
+                required: true
+                type: string
+            bundle_patterns:
+                description: 'JSON array of {name, glob} objects for bundle measurement'
+                required: true
+                type: string
+            node_version:
+                description: 'Node.js version to use'
+                required: false
+                type: string
+                default: '20'
+            npm_install_args:
+                description: 'Extra arguments for npm ci (e.g. --legacy-peer-deps)'
+                required: false
+                type: string
+                default: ''
+            update_readme:
+                description: 'Update the README bundle chart on main'
+                required: false
+                type: boolean
+                default: true
+            history_retention:
+                description: 'Maximum number of entries to keep in history'
+                required: false
+                type: number
+                default: 200
+        secrets:
+            GH_TOKEN:
+                description: 'GitHub token for private npm packages'
+                required: true
+
+permissions:
+    contents: write
+
+jobs:
+    record-sizes:
+        runs-on: self-hosted
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ inputs.node_version }}
+                  cache: 'npm'
+
+            - name: Create .npmrc
+              run: |
+                  echo "@humanoidfr:registry=http://npm.pkg.github.com/" > .npmrc
+                  echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_TOKEN }}" >> .npmrc
+
+            - name: Install dependencies
+              run: npm ci ${{ inputs.npm_install_args }}
+
+            - name: Build client
+              run: ${{ inputs.build_command }}
+
+            - name: Measure bundle sizes (raw + gzip)
+              run: |
+                  node -e "
+                    const fs = require('fs');
+                    const zlib = require('zlib');
+                    const { execSync } = require('child_process');
+                    const patterns = ${{ inputs.bundle_patterns }};
+                    const bundles = {};
+                    for (const p of patterns) {
+                      const files = execSync('ls ' + p.glob + ' 2>/dev/null || true', {encoding:'utf8'}).trim().split('\n').filter(Boolean);
+                      let size = 0, gzip = 0;
+                      for (const f of files) {
+                        try {
+                          const buf = fs.readFileSync(f);
+                          size += buf.length;
+                          gzip += zlib.gzipSync(buf, { level: 9 }).length;
+                        } catch {}
+                      }
+                      bundles[p.name] = { size, gzip };
+                    }
+                    fs.writeFileSync('/tmp/bundle-sizes.json', JSON.stringify(bundles));
+                    console.log(JSON.stringify(bundles, null, 2));
+                  "
+
+            - name: Update bundle history on gh-pages
+              run: |
+                  set -e
+
+                  REPO_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+
+                  # Clone gh-pages or create it
+                  if git ls-remote --exit-code --heads "$REPO_URL" gh-pages > /dev/null 2>&1; then
+                    git clone --branch gh-pages --single-branch --depth 1 "$REPO_URL" gh-pages-dir
+                  else
+                    mkdir -p gh-pages-dir
+                    cd gh-pages-dir
+                    git init -b gh-pages
+                    git remote add origin "$REPO_URL"
+                    cd ..
+                  fi
+
+                  # Ensure directory exists
+                  mkdir -p gh-pages-dir/bundle-history
+
+                  RETENTION=${{ inputs.history_retention }}
+
+                  # Append sizes to history using Node
+                  node -e "
+                    const fs = require('fs');
+                    const historyPath = 'gh-pages-dir/bundle-history/data.json';
+
+                    let history = [];
+                    try { history = JSON.parse(fs.readFileSync(historyPath, 'utf8')); } catch {}
+
+                    const bundles = JSON.parse(fs.readFileSync('/tmp/bundle-sizes.json', 'utf8'));
+
+                    history.push({
+                      sha: '${{ github.sha }}'.slice(0, 7),
+                      date: new Date().toISOString(),
+                      bundles,
+                    });
+
+                    if (history.length > ${RETENTION}) history = history.slice(-${RETENTION});
+
+                    fs.writeFileSync(historyPath, JSON.stringify(history, null, 2));
+                    console.log('History now has ' + history.length + ' entries');
+                  "
+
+                  # Commit and push
+                  cd gh-pages-dir
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git add bundle-history/data.json
+                  git diff --cached --quiet && echo "No changes to commit" && exit 0
+                  git commit -m "chore: update bundle history [skip ci]"
+                  git push origin gh-pages
+
+            - name: Update README bundle chart on main
+              if: inputs.update_readme
+              run: |
+                  set -e
+
+                  REPO_URL="https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+                  git clone --branch main --single-branch --depth 1 "$REPO_URL" main-dir
+
+                  node -e "
+                    const fs = require('fs');
+                    const historyPath = 'gh-pages-dir/bundle-history/data.json';
+                    const readmePath = 'main-dir/README.md';
+
+                    const START = '<!-- BUNDLE-CHART:START -->';
+                    const END = '<!-- BUNDLE-CHART:END -->';
+
+                    const entries = JSON.parse(fs.readFileSync(historyPath, 'utf8'));
+                    const data = entries.slice(-20);
+                    const latest = data[data.length - 1];
+
+                    const fmtKB = (b) => (b / 1024).toFixed(1);
+                    const sha = (s) => s.slice(0, 7);
+
+                    const xLabels = data.map(e => '\"' + sha(e.sha) + '\"').join(', ');
+                    const line = (key) => data.map(e => fmtKB(e.bundles[key]?.gzip || 0)).join(', ');
+
+                    const tableRows = Object.entries(latest.bundles)
+                      .map(([name, { size, gzip }]) => '| ' + name + ' | ' + fmtKB(size) + ' KB | ' + fmtKB(gzip) + ' KB |')
+                      .join('\n');
+
+                    const dateStr = new Date(latest.date).toLocaleDateString('fr-FR');
+
+                    const chart = '### Evolution du bundle (gzip)\n\n' +
+                      '\`\`\`mermaid\n' +
+                      '---\nconfig:\n    xyChart:\n        xAxis:\n            label: \"Commits\"\n        yAxis:\n            label: \"Taille gzip (KB)\"\n        chartOrientation: vertical\n---\n' +
+                      'xychart-beta\n' +
+                      '    x-axis [' + xLabels + ']\n' +
+                      '    line \"React JS\" [' + line('React bundle (JS)') + ']\n' +
+                      '    line \"Script JS\" [' + line('Script bundle (JS)') + ']\n' +
+                      '    line \"JS chunks\" [' + line('JS chunks') + ']\n' +
+                      '    line \"React CSS\" [' + line('React CSS') + ']\n' +
+                      '\`\`\`\n\n' +
+                      '### Snapshot actuel (\`' + sha(latest.sha) + '\` — ' + dateStr + ')\n\n' +
+                      '| Bundle | Taille brute | Gzip |\n' +
+                      '|--------|-------------|------|\n' +
+                      tableRows + '\n\n' +
+                      '> Mis a jour automatiquement par CI a chaque merge sur \`main\`.\n' +
+                      '> Source : [\`bundle-history/data.json\`](https://github.com/${{ github.repository }}/blob/gh-pages/bundle-history/data.json)';
+
+                    const readme = fs.readFileSync(readmePath, 'utf8');
+                    const startIdx = readme.indexOf(START);
+                    const endIdx = readme.indexOf(END);
+
+                    if (startIdx === -1 || endIdx === -1) {
+                      console.log('Markers not found in README.md, skipping');
+                      process.exit(0);
+                    }
+
+                    const updated = readme.slice(0, startIdx + START.length) + '\n\n' + chart + '\n\n' + readme.slice(endIdx);
+                    fs.writeFileSync(readmePath, updated, 'utf8');
+                    console.log('README chart updated');
+                  "
+
+                  cd main-dir
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git add README.md
+                  git diff --cached --quiet && echo "README unchanged" && exit 0
+                  git commit -m "chore: update bundle size chart in README [skip ci]"
+                  git push origin main


### PR DESCRIPTION
Add two reusable workflows callable via workflow_call:
- bundle-analysis.yml: PR size comparison with optional size-limit and treemap
- bundle-history.yml: records bundle sizes to gh-pages with optional README chart