### PR TITLE
fix: add cache-dependency-path for working_directory support

### DIFF
--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -62,6 +62,7 @@ jobs:
               with:
                   node-version: ${{ inputs.node_version }}
                   cache: 'npm'
+                  cache-dependency-path: ${{ inputs.working_directory }}/package-lock.json
 
             - name: Create .npmrc
               working-directory: ${{ inputs.working_directory }}

--- a/.github/workflows/bundle-history.yml
+++ b/.github/workflows/bundle-history.yml
@@ -55,6 +55,7 @@ jobs:
               with:
                   node-version: ${{ inputs.node_version }}
                   cache: 'npm'
+                  cache-dependency-path: ${{ inputs.working_directory }}/package-lock.json
 
             - name: Create .npmrc
               working-directory: ${{ inputs.working_directory }}


### PR DESCRIPTION
setup-node cache looks for package-lock.json at repo root by default, which fails when working_directory is a subdirectory.