### PR TITLE
feat: add pre_build_command input to bundle workflows

### DIFF
--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -41,6 +41,11 @@ on:
                 required: false
                 type: string
                 default: '.'
+            pre_build_command:
+                description: 'Command to run before the build (e.g. install extra deps)'
+                required: false
+                type: string
+                default: ''
         secrets:
             GH_TOKEN:
                 description: 'GitHub token for private npm packages'
@@ -74,6 +79,10 @@ jobs:
             - name: Install dependencies
               working-directory: ${{ inputs.working_directory }}
               run: npm ci ${{ inputs.npm_install_args }}
+
+            - name: Pre-build command
+              if: inputs.pre_build_command != ''
+              run: ${{ inputs.pre_build_command }}
 
             - name: Build PR branch
               working-directory: ${{ inputs.working_directory }}
@@ -142,6 +151,10 @@ jobs:
             - name: Install dependencies (base)
               working-directory: ${{ inputs.working_directory }}
               run: npm ci ${{ inputs.npm_install_args }}
+
+            - name: Pre-build command (base)
+              if: inputs.pre_build_command != ''
+              run: ${{ inputs.pre_build_command }}
 
             - name: Build base branch
               working-directory: ${{ inputs.working_directory }}

--- a/.github/workflows/bundle-history.yml
+++ b/.github/workflows/bundle-history.yml
@@ -36,6 +36,11 @@ on:
                 required: false
                 type: string
                 default: '.'
+            pre_build_command:
+                description: 'Command to run before the build (e.g. install extra deps)'
+                required: false
+                type: string
+                default: ''
         secrets:
             GH_TOKEN:
                 description: 'GitHub token for private npm packages'
@@ -66,6 +71,10 @@ jobs:
             - name: Install dependencies
               working-directory: ${{ inputs.working_directory }}
               run: npm ci ${{ inputs.npm_install_args }}
+
+            - name: Pre-build command
+              if: inputs.pre_build_command != ''
+              run: ${{ inputs.pre_build_command }}
 
             - name: Build client
               working-directory: ${{ inputs.working_directory }}


### PR DESCRIPTION
Allows running arbitrary commands before the build step, e.g. installing dependencies in other directories.